### PR TITLE
Add Github Actions workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,13 +16,13 @@ jobs:
     - id: init
       run: |
         rustup toolchain install stable --profile minimal
-        echo "##[set-output name=sha8;]$(echo ${GITHUB_SHA:0:8})"
+        echo "##[set-output name=sha7;]$(echo ${GITHUB_SHA:0:7})"
     - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --verbose -r
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v3.1.0
       with:
-        name: server-wrapper-${{ steps.init.outputs.sha8 }}
+        name: server-wrapper-${{ steps.init.outputs.sha7 }}
         path: target/release/server-wrapper
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,28 @@
+name: Rust
+
+on:
+  [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - id: init
+      run: |
+        rustup toolchain install stable --profile minimal
+        echo "##[set-output name=sha8;]$(echo ${GITHUB_SHA:0:8})"
+    - uses: Swatinem/rust-cache@v2
+    - name: Build
+      run: cargo build --verbose -r
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v3.1.0
+      with:
+        name: server-wrapper-${{ steps.init.outputs.sha8 }}
+        path: target/release/server-wrapper
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["strip"]
-
 [package]
 name = "server-wrapper"
 version = "0.1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(once_cell)]
-
 use std::collections::HashMap;
 use std::io;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
This PR adds a workflow which builds a release binary & attaches the artifact. It takes advantage of `Swatinem/rust-cache` to cache the building of dependencies, with results of 30s builds on a workflow.

To achieve this, the code needed to be compilable on latest stable. Thus, the declaration for `once_cell` was removed as this is now in stable. This also removes the `strip` cargo feature listing in the manifest for the same reason.